### PR TITLE
Exception if the host is unreachable

### DIFF
--- a/msmart/lan.py
+++ b/msmart/lan.py
@@ -29,11 +29,11 @@ class lan:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(8)
 
-        # Connect the Device
-        device_address = (self.device_ip, self.device_port)
-        sock.connect(device_address)
-
         try:
+            # Connect the Device
+            device_address = (self.device_ip, self.device_port)
+            sock.connect(device_address)
+
             # Send data
             _LOGGER.debug("Sending to %s:%s %s." %
                           (self.device_ip, self.device_port, message.hex()))
@@ -41,6 +41,10 @@ class lan:
 
             # Received data
             response = sock.recv(512)
+        except socket.error:
+            _LOGGER.info("Couldn't connect with Device %s:%s." %
+                (self.device_ip, self.device_port))
+            return bytearray(0)
         except socket.timeout:
             _LOGGER.info("Connect the Device %s:%s TimeOut for 10s. don't care about a small amount of this. if many maybe not support." % (
                 self.device_ip, self.device_port))


### PR DESCRIPTION
If the host is unreachable, there are errors in HA logs.

```
2020-06-16 08:49:47 ERROR (MainThread) [homeassistant.helpers.entity] Update for climate.midea_ac_81YY000000XX fails
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 279, in async_update_ha_state
    await self.async_device_update()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 470, in async_device_update
    await self.async_update()
  File "/config/custom_components/midea_ac/climate.py", line 108, in async_update
    await self.hass.async_add_executor_job(self._device.refresh)
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.7/site-packages/msmart/device.py", line 179, in refresh
    data = self._lan_service.appliance_transparent_send(data)
  File "/usr/local/lib/python3.7/site-packages/msmart/lan.py", line 76, in appliance_transparent_send
    response = bytearray(self.request(data))
  File "/usr/local/lib/python3.7/site-packages/msmart/lan.py", line 34, in request
    sock.connect(device_address)
OSError: [Errno 113] Host is unreachable
```