### PR TITLE
Expose min/max target temperature capabilities

### DIFF
--- a/msmart/device/AC/appliance.py
+++ b/msmart/device/AC/appliance.py
@@ -89,6 +89,8 @@ class air_conditioning(device):
         self._supported_swing_modes = air_conditioning.swing_mode_enum.list()
         self._supports_eco = True
         self._supports_turbo = True
+        self._min_target_temperature = 16
+        self._max_target_temperature = 30
 
         self._on_timer = None
         self._off_timer = None
@@ -221,6 +223,9 @@ class air_conditioning(device):
         self._supports_eco = res.eco_mode
         self._supports_turbo = res.turbo_mode
 
+        self._min_target_temperature = res.min_temperature
+        self._max_target_temperature = res.max_temperature
+
     @property
     def prompt_tone(self):
         return self._prompt_tone
@@ -334,3 +339,11 @@ class air_conditioning(device):
     @property
     def supported_swing_modes(self):
         return self._supported_swing_modes
+
+    @property
+    def min_target_temperature(self):
+        return self._min_target_temperature
+
+    @property
+    def max_target_temperature(self):
+        return self._max_target_temperature

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -341,12 +341,12 @@ class capabilities_response(response):
                 if size < 6:
                     continue
 
-                self.capabilities["min_cool_temperature"] = caps[3] * 0.5
-                self.capabilities["max_cool_temperature"] = caps[4] * 0.5
-                self.capabilities["min_auto_temperature"] = caps[5] * 0.5
-                self.capabilities["max_auto_temperature"] = caps[6] * 0.5
-                self.capabilities["min_heat_temperature"] = caps[7] * 0.5
-                self.capabilities["max_heat_temperature"] = caps[8] * 0.5
+                self.capabilities["cool_min_temperature"] = caps[3] * 0.5
+                self.capabilities["cool_max_temperature"] = caps[4] * 0.5
+                self.capabilities["auto_min_temperature"] = caps[5] * 0.5
+                self.capabilities["auto_max_temperature"] = caps[6] * 0.5
+                self.capabilities["heat_min_temperature"] = caps[7] * 0.5
+                self.capabilities["heat_max_temperature"] = caps[8] * 0.5
 
                 self.capabilities["decimals"] = caps[9] == 0 if size > 6 else caps[2] == 0
 
@@ -392,6 +392,16 @@ class capabilities_response(response):
     @property
     def turbo_mode(self):
         return self.capabilities.get("turbo_heat", False) or self.capabilities.get("turbo_cool", False)
+
+    @property
+    def min_temperature(self):
+        mode = ["cool", "auto", "heat"]
+        return min([self.capabilities.get(f"{m}_min_temperature", 16) for m in mode])
+
+    @property
+    def max_temperature(self):
+        mode = ["cool", "auto", "heat"]
+        return max([self.capabilities.get(f"{m}_max_temperature", 30) for m in mode])
 
 class state_response(response):
     def __init__(self, frame: bytes):


### PR DESCRIPTION
Expose min/max target temperature values for the AC device class. These values are derived from the capabilities response if they exist.