### PR TITLE
Revert "fix enm to list"

### DIFF
--- a/msmart/device/AC/appliance.py
+++ b/msmart/device/AC/appliance.py
@@ -329,8 +329,8 @@ class air_conditioning(device):
 
     @property
     def supported_operation_modes(self):
-        return self._supported_op_modes
+        return IntEnumHelper.names(self._supported_op_modes)
 
     @property
     def supported_swing_modes(self):
-        return self._supported_swing_modes
+        return IntEnumHelper.names(self._supported_swing_modes)


### PR DESCRIPTION
This reverts commit 06167aba8566b3b5d0d013bcb911ced582363997. Commit 06167aba8566b3b5d0d013bcb911ced582363997 was a breaking change for mac-zhou/midea-ac-py.

Close #90, and close mac-zhou/midea-ac-py#186 (also noted in mac-zhou/midea-ac-py#183).

I do think it's a little odd to return strings instead of the enum types, but it makes the behavior consistent with other usages like `fan_speed_enum.list()` and `operational_mode_enum.list()`