### PR TITLE
Fix handling of missing temperature values

### DIFF
--- a/msmart/device/AC/appliance.py
+++ b/msmart/device/AC/appliance.py
@@ -94,8 +94,8 @@ class air_conditioning(device):
         self._off_timer = None
         self._online = True
         self._active = True
-        self._indoor_temperature = 0.0
-        self._outdoor_temperature = 0.0
+        self._indoor_temperature = None
+        self._outdoor_temperature = None
 
     def __str__(self):
         return str(self.__dict__)
@@ -183,12 +183,8 @@ class air_conditioning(device):
         self._eco_mode = res.eco_mode
         self._turbo_mode = res.turbo_mode
         self._fahrenheit_unit = res.fahrenheit
-
-        if res.indoor_temperature != 0xff:
-            self._indoor_temperature = res.indoor_temperature
-
-        if res.outdoor_temperature != 0xff:
-            self._outdoor_temperature = res.outdoor_temperature
+        self._indoor_temperature = res.indoor_temperature
+        self._outdoor_temperature = res.outdoor_temperature
 
         # self._on_timer = res.on_timer
         # self._off_timer = res.off_timer

--- a/msmart/device/AC/command.py
+++ b/msmart/device/AC/command.py
@@ -467,9 +467,9 @@ class state_response(response):
         # self.peak_elec = (payload[10] & 0x20) > 0
         # self.natural_fan = (payload[10] & 0x40) > 0
 
-        self.indoor_temperature = (payload[11] - 50) / 2.0
+        self.indoor_temperature = (payload[11] - 50) / 2.0 if payload[11] != 0xff else None
 
-        self.outdoor_temperature = (payload[12] - 50) / 2.0
+        self.outdoor_temperature = (payload[12] - 50) / 2.0 if payload[12] != 0xff else None
 
         # self.humidity = (payload[13] & 0x7F)
 


### PR DESCRIPTION
Move test for missing temperature value from appliance.py to command.py, so it is performed on the raw payload. Currently, the test is performed on the value after conversion, so it never holds, and missing temp values result in a 102.5C temp.
Also, change default temp values from 0 to None.
